### PR TITLE
Update faraday dependancy requirements

### DIFF
--- a/tumblr_client.gemspec
+++ b/tumblr_client.gemspec
@@ -2,8 +2,8 @@
 require File.join(File.dirname(__FILE__), 'lib/tumblr/version')
 
 Gem::Specification.new do |gem|
-  gem.add_dependency 'faraday', '~> 0.9'
-  gem.add_dependency 'faraday_middleware', '~> 0.9'
+  gem.add_dependency 'faraday', '<=1.3.0'
+  gem.add_dependency 'faraday_middleware', '<= 1.3.0'
   gem.add_dependency 'json'
   gem.add_dependency 'simple_oauth'
   gem.add_dependency 'oauth'


### PR DESCRIPTION
Need to use this gem (https://github.com/googleapis/google-cloud-ruby/tree/master/google-analytics-data) in the main app, and faraday dependencies on this client were too old.

Updated to be `<=1.3.0` as the error message I was receiving was:
```
Bundler could not find compatible versions for gem
"faraday":
  In snapshot (Gemfile.lock):
    faraday (= 0.17.4)

  In Gemfile:
google-analytics-data-v1beta was resolved to
0.2.0, which depends on
gapic-common (< 2.a, >= 0.5) was resolved to
0.7.0, which depends on
        faraday (~> 1.3)

tumblr_client was resolved to 0.8.5, which
depends on
      faraday (~> 0.9)
```