### PR TITLE
updated faraday version from 1.3.0 to 1.10.0

### DIFF
--- a/tumblr_client.gemspec
+++ b/tumblr_client.gemspec
@@ -2,8 +2,8 @@
 require File.join(File.dirname(__FILE__), 'lib/tumblr/version')
 
 Gem::Specification.new do |gem|
-  gem.add_dependency 'faraday', '<=1.3.0'
-  gem.add_dependency 'faraday_middleware', '<= 1.3.0'
+  gem.add_dependency 'faraday', '<=1.10.0'
+  gem.add_dependency 'faraday_middleware', '<= 1.10.0'
   gem.add_dependency 'json'
   gem.add_dependency 'simple_oauth'
   gem.add_dependency 'oauth'


### PR DESCRIPTION
## Change description

Updated version of faraday to 1.10.0
To remove the warning
```
Top level ::CompositeIO is deprecated, require 'multipart/post' and use `Multipart::Post::CompositeReadIO` instead!
```

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Part 1 of [GLM-2424](https://linear.app/gleamio/issue/GLM-2424/multipart-warning)


