### PR TITLE
GLM-14216 - Update Faraday gem

### DIFF
--- a/lib/tumblr/connection.rb
+++ b/lib/tumblr/connection.rb
@@ -7,7 +7,7 @@ require 'forwardable'
 # to remove dependency on deprecated faraday middleware gem
 module FaradayMiddleware
   class OAuth < Faraday::Middleware
-    dependency 'simple_oauth'
+    require 'simple_oauth'
     AUTH_HEADER = 'Authorization'
     CONTENT_TYPE = 'Content-Type'
     TYPE_URLENCODED = 'application/x-www-form-urlencoded'
@@ -181,9 +181,7 @@ module FaradayMiddleware
 
   # Public: Parse response bodies as JSON.
   class ParseJson < ResponseMiddleware
-    dependency do
-      require 'json' unless defined?(::JSON)
-    end
+    require 'json' unless defined?(::JSON)
 
     define_parser do |body, parser_options|
       ::JSON.parse(body, parser_options || {}) unless body.strip.empty?


### PR DESCRIPTION
## Change description

Replace FaradayMiddleware dependency blocks with direct require statements for simple_oauth and json.

This needs to be done to properly update the faraday gem on the poller repo